### PR TITLE
fix: attach x-torima-userid when auth is not forced

### DIFF
--- a/extension/directors/auth.go
+++ b/extension/directors/auth.go
@@ -1,8 +1,6 @@
 package directors
 
 import (
-	"fmt"
-
 	"github.com/ochanoco/ninsho"
 	gin_ninsho "github.com/ochanoco/ninsho/extension/gin"
 	"github.com/ochanoco/torima/core"
@@ -26,24 +24,19 @@ func SkipAuthDirector(c *core.TorimaDirectorPackageContext) (core.TorimaPackageS
 }
 
 func AuthDirector(c *core.TorimaDirectorPackageContext) (core.TorimaPackageStatus, error) {
-	if c.PackageStatus == core.NoAuthNeeded {
-		return core.NoAuthNeeded, nil
-	}
-
 	user, err := gin_ninsho.LoadUser[ninsho.LINE_USER](c.GinContext)
-
 	// just to be sure
 	c.Target.Header.Del("X-Torima-UserID")
 
-	if err != nil {
-		err = utils.MakeError(err, "failed to get user from session: ")
+	if err != nil || user == nil {
+		if c.PackageStatus == core.NoAuthNeeded {
+			return core.NoAuthNeeded, nil
+		}
+
+		err = utils.MakeError(err, "failed to authenticate: ")
 		return core.ForceStop, err
 	}
 
-	if user != nil {
-		c.Target.Header.Set("X-Torima-UserID", user.Sub)
-		return core.Authed, nil
-	}
-
-	return core.ForceStop, utils.MakeError(fmt.Errorf(""), utils.UnauthorizedErrorTag)
+	c.Target.Header.Set("X-Torima-UserID", user.Sub)
+	return core.Authed, nil
 }


### PR DESCRIPTION
Fix the bug that x-torima-userid is missing when the user accesses the path not forced authentication